### PR TITLE
Mute command output

### DIFF
--- a/.clash.yml
+++ b/.clash.yml
@@ -1,3 +1,3 @@
 title: Run clash via test.rb so results can be logged can compared.
-before: ruby test.rb
-compare: _expected_output _output 
+before: DEBUG=true ruby test.rb
+compare: _expected_output _output

--- a/lib/clash/helpers.rb
+++ b/lib/clash/helpers.rb
@@ -35,6 +35,14 @@ module Clash
       end
     end
 
+    def system(*cmd)
+      Kernel.system("#{cmd.join(' ')} > #{output_file}")
+    end
+
+    def output_file
+      @output_file ||= (ENV['DEBUG'] ? '/dev/stdout' : '/dev/null')
+    end
+
     # Print a single character without a newline
     #
     def pout(str)

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,6 +1,6 @@
 require 'clash'
 
-count = Clash::Tests.new().tests.size
+count = Clash::Tests.new.tests.size
 FileUtils.mkdir_p('_output')
 
 puts "Running #{count} tests..."
@@ -15,8 +15,8 @@ end
 # This allows tests to pass on different systems
 %w{1 2}.each do |f|
   content = File.open("_output/#{f}").read
-  content = content.gsub(/Configuration file: .+\//, 'Configuration file: ') 
-    .gsub(/Source: .+\//, 'Source: ') 
+  content = content.gsub(/Configuration file: .+\//, 'Configuration file: ')
+    .gsub(/Source: .+\//, 'Source: ')
     .gsub(/Destination: .+\//, 'Destination: ')
 
   File.open("_output/#{f}", 'w') { |f| f.write(content) }


### PR DESCRIPTION
In the [test output for `octopress/octopress`](https://travis-ci.org/octopress/octopress/jobs/46408073#L147), there is a lot of noise. Sometimes the output from various commands is useful, but usually only for debugging purposes. In Clash's case, we're trying to check whether the commands produced the correct output to the file system, not to the console. As such, mute the output of any `system` commands.

To disable, use `DEBUG=true`.