### PR TITLE
add mkdir before cp when using accept

### DIFF
--- a/lib/clash/test.rb
+++ b/lib/clash/test.rb
@@ -122,6 +122,7 @@ module Clash
             FileUtils.mkdir_p(f.first)
             FileUtils.cp_r(File.join(f.last, '.'), f.first)
           else
+            FileUtils.mkdir_p File.dirname(f.first)
             FileUtils.cp f.last, f.first
           end
 


### PR DESCRIPTION
Avoiding error when we run `clash accept` for the first time and the directory doesn't exist.